### PR TITLE
Add script to compute docker image tag

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -38,12 +38,12 @@ pypi_release:
 	twine upload dist/*
 
 image:
-	docker build -f $(XSAMTOOLS_HOME)/Dockerfile --build-arg XSAMTOOLS_DOCKER_USER --build-arg XSAMTOOLS_HOME -t $(XSAMTOOLS_IMAGE_NAME) .
+	docker build -f $(XSAMTOOLS_HOME)/Dockerfile --build-arg XSAMTOOLS_DOCKER_USER --build-arg XSAMTOOLS_HOME -t $(XSAMTOOLS_IMAGE_BASE_NAME) .
 
 image-force:
-	docker build --no-cache -f $(XSAMTOOLS_HOME)/Dockerfile --build-arg XSAMTOOLS_DOCKER_USER --build-arg XSAMTOOLS_HOME -t $(XSAMTOOLS_IMAGE_NAME) .
+	docker build --no-cache -f $(XSAMTOOLS_HOME)/Dockerfile --build-arg XSAMTOOLS_DOCKER_USER --build-arg XSAMTOOLS_HOME -t $(XSAMTOOLS_IMAGE_BASE_NAME) .
 
 publish-image: image
-	docker push $(XSAMTOOLS_IMAGE_NAME)
+	docker push $(XSAMTOOLS_IMAGE_BASE_NAME)
 
 .PHONY: release image image-force publish-image

--- a/docker_scripts/image_tag.sh
+++ b/docker_scripts/image_tag.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# This script outputs the docker image tag
+set -euo pipefail
+VERSION=$(git describe --tags --match "v*.*.*" | cut -d '-' -f1)
+echo "${XSAMTOOLS_IMAGE_BASE_NAME}-${VERSION}"

--- a/environment
+++ b/environment
@@ -5,5 +5,5 @@ export XSAMTOOLS_HOME="$(cd -P "$(dirname "$SOURCE")" && pwd)"
 
 set -a
 XSAMTOOLS_DOCKER_USER="xsamtools"  # name of user created in Dockerfile
-XSAMTOOLS_IMAGE_NAME="xbrianh/xsamtools"
+XSAMTOOLS_IMAGE_BASE_NAME="xbrianh/xsamtools"
 set +a


### PR DESCRIPTION
This script uses the latest tagged version from the git repo to output `${XSAMTOOLS_IMAGE_BASE_NAME}-${VERSION}`

depends on #55 