### PR TITLE
Add flake8 exception for E127.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 max-line-length=120
-ignore: E301, E302, E305, E401, F401, W503, W504, W605, E252
+ignore: E301, E302, E305, E401, F401, W503, W504, W605, E127

--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 max-line-length=120
-ignore: E301, E302, E305, E401, F401, W503, W504, W605, E127
+ignore: E301, E302, E305, E401, F401, W503, W504, W605, E252, E127


### PR DESCRIPTION
This is a style consideration.  Currently tests in `test_cram` look like this:

```
        test_regions = 'CHROMOSOME_I,CHROMOSOME_III:1,CHROMOSOME_IV'
        with self.subTest(f'Test xsamtools view cram with regions: "{test_regions}"'):
            stdout, stderr = self.cram_view_with_regions(cram, crai, regions=test_regions)
            self.assertEqual(stdout, self.regions['CHROMOSOME_I']['expected_output'] +
                                     self.regions['CHROMOSOME_III']['expected_output'] +
                                     self.regions['CHROMOSOME_IV']['expected_output'])
```

Which flake8 doesn't like, but I do.  If asked, I'll change to the flake8 indent style, but I'd prefer to keep it the way it is.

Actual error is:

```
./tests/test_cram.py:159:38: E127 continuation line over-indented for visual indent
./tests/test_cram.py:165:38: E127 continuation line over-indented for visual indent
./tests/test_cram.py:166:38: E127 continuation line over-indented for visual indent
./tests/test_cram.py:172:38: E127 continuation line over-indented for visual indent
./tests/test_cram.py:173:38: E127 continuation line over-indented for visual indent
./tests/test_cram.py:179:38: E127 continuation line over-indented for visual indent
./tests/test_cram.py:180:38: E127 continuation line over-indented for visual indent
```