### PR TITLE
Add cram file definition.

### DIFF
--- a/.cache/v/cache/lastfailed
+++ b/.cache/v/cache/lastfailed
@@ -1,3 +1,0 @@
-{
-  "tests/test_cram.py": true
-}

--- a/.cache/v/cache/lastfailed
+++ b/.cache/v/cache/lastfailed
@@ -1,0 +1,3 @@
+{
+  "tests/test_cram.py": true
+}

--- a/tests/test_cram.py
+++ b/tests/test_cram.py
@@ -233,6 +233,14 @@ class TestCram(unittest.TestCase):
     def test_read_crai(self):
         self.assertEqual(len(cram.get_crai_indices(self.crai_local_path)), 5)
 
+    def test_read_cram_file_definition(self):
+        expected = {'cram': 'CRAM',
+                    'major_version': 2,
+                    'minor_version': 0,
+                    'file_id': '-\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'}
+        with open(self.cram_local_path, 'rb') as f:
+            cram_file_definition = cram.file_definition(f)
+        self.assertEqual(cram_file_definition, expected, f'{cram_file_definition} is not: {expected}')
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_cram.py
+++ b/tests/test_cram.py
@@ -239,7 +239,7 @@ class TestCram(unittest.TestCase):
                     'minor_version': 0,
                     'file_id': '-\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'}
         with open(self.cram_local_path, 'rb') as f:
-            cram_file_definition = cram.file_definition(f)
+            cram_file_definition = cram.read_fixed_length_cram_file_definition(f)
         self.assertEqual(cram_file_definition, expected, f'{cram_file_definition} is not: {expected}')
 
 if __name__ == '__main__':

--- a/xsamtools/cram.py
+++ b/xsamtools/cram.py
@@ -31,7 +31,7 @@ def read_fixed_length_cram_file_definition(fh: io.BytesIO):
     -------------------------------------------------------------------------------------------------
     | Data type       Name                   Value                                                  |
     -------------------------------------------------------------------------------------------------
-    | byte[4          format magic number    CRAM (0x43 0x52 0x41 0x4d)                             |
+    | byte[4]         format magic number    CRAM (0x43 0x52 0x41 0x4d)                             |
     | unsigned byte   major format number    3 (0x3)                                                |
     | unsigned byte   minor format number    0 (0x0)                                                |
     | byte[20]        file id                CRAM file identifier (e.g. file name or SHA1 checksum) |

--- a/xsamtools/cram.py
+++ b/xsamtools/cram.py
@@ -22,7 +22,28 @@ from xsamtools import gs_utils
 CramLocation = namedtuple("CramLocation", "chr alignment_start alignment_span offset slice_offset slice_size")
 log = logging.getLogger(__name__)
 
-def file_definition(fh):
+def read_fixed_length_cram_file_definition(fh: io.BinaryIO):
+    """
+    This definition is always the first 26 bytes of a cram file.
+
+    From CRAM spec 3.0 (22 Jun 2020):
+
+    -------------------------------------------------------------------------------------------------
+    | Data type       Name                   Value                                                  |
+    -------------------------------------------------------------------------------------------------
+    | byte[4          format magic number    CRAM (0x43 0x52 0x41 0x4d)                             |
+    | unsigned byte   major format number    3 (0x3)                                                |
+    | unsigned byte   minor format number    0 (0x0)                                                |
+    | byte[20]        file id                CRAM file identifier (e.g. file name or SHA1 checksum) |
+    -------------------------------------------------------------------------------------------------
+
+    Valid CRAM major.minor version numbers are as follows:
+        1.0 The original public CRAM release.
+        2.0 The first CRAM release implemented in both Java and C; tidied up implementation vs specification
+        differences in 1.0.
+        2.1 Gained end of file markers; compatible with 2.0.
+        3.0 Additional compression methods; header and data checksums; improvements for unsorted data.
+    """
     return {
         'cram': fh.read(4).decode('utf-8'),
         'major_version': int.from_bytes(fh.read(1), byteorder='little'),  # order shouldn't matter with 1 byte

--- a/xsamtools/cram.py
+++ b/xsamtools/cram.py
@@ -22,7 +22,7 @@ from xsamtools import gs_utils
 CramLocation = namedtuple("CramLocation", "chr alignment_start alignment_span offset slice_offset slice_size")
 log = logging.getLogger(__name__)
 
-def read_fixed_length_cram_file_definition(fh: io.BinaryIO):
+def read_fixed_length_cram_file_definition(fh: io.BytesIO):
     """
     This definition is always the first 26 bytes of a cram file.
 

--- a/xsamtools/cram.py
+++ b/xsamtools/cram.py
@@ -22,6 +22,13 @@ from xsamtools import gs_utils
 CramLocation = namedtuple("CramLocation", "chr alignment_start alignment_span offset slice_offset slice_size")
 log = logging.getLogger(__name__)
 
+def file_definition(fh):
+    return {
+        'cram': fh.read(4).decode('utf-8'),
+        'major_version': int.from_bytes(fh.read(1), byteorder='little'),  # order shouldn't matter with 1 byte
+        'minor_version': int.from_bytes(fh.read(1), byteorder='little'),  # but it's required
+        'file_id': fh.read(20).decode('utf-8')
+    }
 
 def get_crai_indices(crai):
     crai_indices = []


### PR DESCRIPTION
This allows reading the very first (unique) header of a cram file which is exactly 26 bytes long.