### PR TITLE
Pin six

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 terra-notebook-utils >= 0.7.0, < 0.8.0
 cli-builder >= 0.1.4, < 0.2.0
+six >= 1.15.0


### PR DESCRIPTION
[six](https://pypi.org/project/six/) is an unpinned dependency of google cloud client libraries.
Old versions cause breakage. Pin it here.