### PR TITLE
Enable CI/CD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+  - 3.8
+install:
+  - pip install -r requirements-dev.txt
+  - source environment
+script:
+  - make lint mypy


### PR DESCRIPTION
The test code base is not ready for CI/CD. Enable linting and static
analysis for now.

depends on #84 